### PR TITLE
Remove `data-tooltip` from tag buttons to avoid native tooltip

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2983,7 +2983,6 @@ function TagSidebar({
                 onTouchStart={() => handleTagTouchStart(tag)}
                 onTouchEnd={handleTagTouchEnd}
                 onTouchCancel={handleTagTouchEnd}
-                data-tooltip={tag}
               >
                 <span className="flex items-center gap-2 truncate"><TagIcon />{tag}</span>
                 <span className="text-xs opacity-70">{count}</span>


### PR DESCRIPTION
### Motivation
- Prevent the browser-native tooltip that was being set via `data-tooltip={tag}` on tag buttons, which conflicted with the component's custom long-press/touch behavior and UI.

### Description
- Remove the `data-tooltip` attribute from the tag `button` in `TagSidebar` within `src/App.jsx` so the native tooltip no longer appears.

### Testing
- No automated tests were run for this trivial UI attribute change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cc7205f48324b79c70e56a55f9a6)